### PR TITLE
Remove duplicate ids

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -19,7 +19,7 @@ const handleDisplay = (array) => {
                 <span id="title${item.index}" ${showText}>${item.description}</span>
             </div>
 
-             <div id="${item.index}" class="deleteButton" title="Delete Task" onmousedown="return false" >
+             <div id="delete${item.index}" class="deleteButton" title="Delete Task" onmousedown="return false" >
                 <i class="fas fa-trash-alt icon"></i>
               </div>  
           </div>

--- a/src/functions.js
+++ b/src/functions.js
@@ -14,7 +14,7 @@ const handleToggleComplete = (index, array) => {
 const handleDelete = (index, array) => {
   if (index) {
     const selectedTask = array.filter((item) => {
-      if (Number(index) !== item.index) return true;
+      if (parseInt(index.replace(/[^0-9]/g, '')) !== item.index) return true;
       return null;
     });
     return selectedTask;


### PR DESCRIPTION
Remove the use of the same id in multiple places.

The todo-id was used in multiple places. This was removed following the DRY principle